### PR TITLE
Idea: tokio::spawn to reduce risk of missing processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracer-daemon"
-version = "0.0.11"
+version = "0.0.12"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracer-daemon"
-version = "0.0.12"
+version = "0.0.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracer-daemon"
-version = "0.0.11"
+version = "0.0.12"
 edition = "2021"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracer-daemon"
-version = "0.0.12"
+version = "0.0.14"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Tracer Daemon Instructions
 
+## Where to test the Daemon?
+
+Press the gitpod button here:
+
+- https://github.com/TracerBio/tracer-workflow-templates
+
 ## How to check if Tracer Daemon Is Running:
 
 $ps -e | grep tracer

--- a/install-tracer.sh
+++ b/install-tracer.sh
@@ -419,7 +419,7 @@ setup_tracer_configuration_file() {
 polling_interval_ms = 1500
 api_key = "$API_KEY"
 targets = [
-    "STAR",
+       "STAR",
     "bowtie2",
     "bwa",
     "salmon",
@@ -428,6 +428,8 @@ targets = [
     "samtools",
     "bedtools",
     "deeptools",
+    "macs3",
+    "plotCoverage",
     "MACS33",
     "Genrich",
     "TopHat",

--- a/install-tracer.sh
+++ b/install-tracer.sh
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # https://github.com/davincios/tracer-daemon/releases/download/v0.0.8/tracer-daemon-universal-apple-darwin.tar.gz
 SCRIPT_VERSION="v0.0.1"
-TRACER_VERSION="v0.0.11"
+TRACER_VERSION="v0.0.12"
 TRACER_LINUX_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-x86_64-unknown-linux-gnu.tar.gz"
 TRACER_MACOS_AARCH_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-aarch64-apple-darwin.tar.gz"
 TRACER_MACOS_UNIVERSAL_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-universal-apple-darwin.tar.gz"

--- a/install-tracer.sh
+++ b/install-tracer.sh
@@ -17,7 +17,7 @@
 #-------------------------------------------------------------------------------
 # https://github.com/davincios/tracer-daemon/releases/download/v0.0.8/tracer-daemon-universal-apple-darwin.tar.gz
 SCRIPT_VERSION="v0.0.1"
-TRACER_VERSION="v0.0.12"
+TRACER_VERSION="v0.0.14"
 TRACER_LINUX_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-x86_64-unknown-linux-gnu.tar.gz"
 TRACER_MACOS_AARCH_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-aarch64-apple-darwin.tar.gz"
 TRACER_MACOS_UNIVERSAL_URL="https://github.com/davincios/tracer-daemon/releases/download/${TRACER_VERSION}/tracer-daemon-universal-apple-darwin.tar.gz"
@@ -426,7 +426,6 @@ setup_tracer_configuration_file() {
         rm -f $TEMP_FILE
         return 1
     fi
-
 
     # Create the destination directory if it doesn't exist
     mkdir -p ~/.config/tracer

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,12 +31,12 @@ async fn async_main() -> Result<()> {
     )?)?;
 
     let mut tr = TracerClient::from_config(config)?;
-
+    // timeout is removed completely, it goes as fast as it can
     loop {
         tr.remove_completed_processes().await?;
         tr.poll_processes().await?;
 
-        tr.send_metrics().await?; // this might take too long?
+        // tr.send_metrics().await?; // this might take too long?
         tr.refresh();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ async fn async_main() -> Result<()> {
         tr.remove_completed_processes().await?;
         tr.poll_processes().await?;
 
-        tr.send_metrics().await?;
+        tr.send_metrics().await?; // this might take too long?
         tr.refresh();
     }
 }

--- a/tracer.toml
+++ b/tracer.toml
@@ -1,4 +1,4 @@
-polling_interval_ms = 3000
+polling_interval_ms = 1500
 api_key = "RbGK7dN6A2hlDn0uqEuVA"
 targets = [
     "STAR",
@@ -10,6 +10,8 @@ targets = [
     "samtools",
     "bedtools",
     "deeptools",
+    "macs3",
+    "plotCoverage",
     "MACS33",
     "Genrich",
     "TopHat",
@@ -63,5 +65,5 @@ targets = [
     "HiC-Pro",
     "cooler",
     "cooltools",
-    "runHiC"
+    "runHiC",
 ]


### PR DESCRIPTION
Code achieves concurrent execution by spawning a background task using tokio::spawn to send information to our back-end service via the send_event_with_arc function.

This way the polling operation is not delayed by potentially time-consuming network requests. 

As a result, the daemon system can continue to monitor and record new processes without interruption, reducing the risk of missing any processes during the polling cycle